### PR TITLE
Modificar http a https

### DIFF
--- a/swagger.js
+++ b/swagger.js
@@ -20,7 +20,7 @@ const doc = {
             description: "Local server",
         },
         {
-            url: "http://dreamlab-api.azurewebsites.net/",
+            url: "https://dreamlab-api.azurewebsites.net/",
             description: "Live server",
         },
     ],


### PR DESCRIPTION
## Descripción de cambios
-  Modificar http a https para el servidor de azure en la documentación de swagger
