### PR TITLE
Filtros cronograma

### DIFF
--- a/controllers/estatus.js
+++ b/controllers/estatus.js
@@ -1,0 +1,57 @@
+import express from "express";
+import { config } from "../config.js";
+import Database from "../database.js";
+
+const router = express.Router();
+router.use(express.json());
+
+// Create database object
+const database = new Database(config);
+
+router.get("/", async (_, res) => {
+    /*
+    #swagger.tags = ['Estatus']
+    #swagger.description = 'Obtiene todos los estatus'
+    #swagger.summary = 'Obtiene todos los estatus'
+    #swagger.responses[200] = {
+        description: 'OK',
+        content: {
+            'application/json': {
+                schema: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            idEstatus: { type: 'integer' },
+                            nombre: { type: 'string' },
+                            descripcion: { type: 'string' }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    #swagger.responses[500] = {
+        description: 'Error',
+        content: {
+            'application/json': {
+                schema: {
+                    type: 'object',
+                    properties: {
+                        error: { type: 'string' }
+                    }
+                }
+            }
+        }
+    }
+    */
+    try {
+        // Regresa todas las experiencias
+        const estatus = await database.readAll("Estatus");
+        res.status(200).json(estatus);
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+export default router;

--- a/queries/Setup.sql
+++ b/queries/Setup.sql
@@ -157,6 +157,7 @@ CREATE TABLE
         idExperiencia INT,
         idMesa INT,
         estatus INT,
+        estatusMateriales INT,
         horaInicio TIME,
         duracion INT,
         fecha DATE,
@@ -165,7 +166,8 @@ CREATE TABLE
         FOREIGN KEY (idSala) REFERENCES Salas (idSala),
         FOREIGN KEY (idExperiencia) REFERENCES Experiencias (idExperiencia),
         FOREIGN KEY (idMesa) REFERENCES Mesas (idMesa),
-        FOREIGN KEY (estatus) REFERENCES Estatus (idEstatus)
+        FOREIGN KEY (estatus) REFERENCES Estatus (idEstatus),
+        FOREIGN KEY (estatusMateriales) REFERENCES Estatus (idEstatus)
     );
 
 CREATE TABLE
@@ -205,7 +207,7 @@ CREATE TABLE
 INSERT INTO
     Estatus (nombre, descripcion)
 VALUES
-    ('Completado', 'El material ha sido preparado'),
+    ('Preparado', 'El material ha sido preparado'),
     (
         'En progreso',
         'El material esta siendo preparado'
@@ -219,6 +221,10 @@ VALUES
     (
         'Denegada',
         'La solicitud de reserva ha sido negada'
+    ),
+    (
+        'Sin preparar',
+        'El material no ha sido preparado'
     );
 
 -- Sample data for UnidadesFormacion

--- a/queries/triggers/trg_ActualizarEstatusMateriales.sql
+++ b/queries/triggers/trg_ActualizarEstatusMateriales.sql
@@ -3,17 +3,20 @@ ON ReservacionesMateriales
 AFTER UPDATE
 AS
 BEGIN
-    -- Declare variables to hold reservation id and status counts
+    -- Variables para guardar el id de la reservación de la cual se está
+    -- modificando el estatus de sus materiales. Asimismo, se guarda el conteo
+    -- de materiales completados, en progreso y no completados.
     DECLARE @idReservacion INT;
+    DECLARE @allCompleted INT, @inProgress INT, @noneCompleted INT;
 
-    -- Get the reservation id from the updated rows
+    -- Se obtiene el id de la reservación de la cual se está modificando el
+    -- estatus de sus materiales.
     SELECT @idReservacion = inserted.idReservacion
     FROM inserted
     GROUP BY inserted.idReservacion;
 
-    -- Check the status of all materials for the reservation
-    DECLARE @allCompleted INT, @inProgress INT, @noneCompleted INT;
-
+    -- Se obtiene el conteo de materiales completados, en progreso y no
+    -- completados. 
     SELECT 
         @allCompleted = SUM(CASE WHEN estatus = 1 THEN 1 ELSE 0 END),
         @inProgress = SUM(CASE WHEN estatus = 6 THEN 1 ELSE 0 END),
@@ -21,24 +24,24 @@ BEGIN
     FROM ReservacionesMateriales
     WHERE idReservacion = @idReservacion;
 
-    -- Update the estatusMateriales field in Reservaciones table
+    -- Se actualiza el estatus de los materiales de la reservación.
+    -- Si todos los materiales están completados
     IF @allCompleted > 0 AND @noneCompleted = 0
     BEGIN
-        -- All materials are completed
         UPDATE Reservaciones
         SET estatusMateriales = 1
         WHERE idReservacion = @idReservacion;
     END
+    -- Si algunos materiales están completados, pero no todos
     ELSE IF @allCompleted > 0
     BEGIN
-        -- Some materials are completed, but not all
         UPDATE Reservaciones
         SET estatusMateriales = 2
         WHERE idReservacion = @idReservacion;
     END
+    -- Si ningún material está completado
     ELSE
     BEGIN
-        -- No materials are completed
         UPDATE Reservaciones
         SET estatusMateriales = 6
         WHERE idReservacion = @idReservacion;

--- a/queries/triggers/trg_ActualizarEstatusMateriales.sql
+++ b/queries/triggers/trg_ActualizarEstatusMateriales.sql
@@ -1,0 +1,46 @@
+CREATE OR ALTER TRIGGER trg_ActualizarEstatusMateriales
+ON ReservacionesMateriales
+AFTER UPDATE
+AS
+BEGIN
+    -- Declare variables to hold reservation id and status counts
+    DECLARE @idReservacion INT;
+
+    -- Get the reservation id from the updated rows
+    SELECT @idReservacion = inserted.idReservacion
+    FROM inserted
+    GROUP BY inserted.idReservacion;
+
+    -- Check the status of all materials for the reservation
+    DECLARE @allCompleted INT, @inProgress INT, @noneCompleted INT;
+
+    SELECT 
+        @allCompleted = SUM(CASE WHEN estatus = 1 THEN 1 ELSE 0 END),
+        @inProgress = SUM(CASE WHEN estatus = 6 THEN 1 ELSE 0 END),
+        @noneCompleted = SUM(CASE WHEN estatus = 1 THEN 0 ELSE 1 END)
+    FROM ReservacionesMateriales
+    WHERE idReservacion = @idReservacion;
+
+    -- Update the estatusMateriales field in Reservaciones table
+    IF @allCompleted > 0 AND @noneCompleted = 0
+    BEGIN
+        -- All materials are completed
+        UPDATE Reservaciones
+        SET estatusMateriales = 1
+        WHERE idReservacion = @idReservacion;
+    END
+    ELSE IF @allCompleted > 0
+    BEGIN
+        -- Some materials are completed, but not all
+        UPDATE Reservaciones
+        SET estatusMateriales = 2
+        WHERE idReservacion = @idReservacion;
+    END
+    ELSE
+    BEGIN
+        -- No materials are completed
+        UPDATE Reservaciones
+        SET estatusMateriales = 6
+        WHERE idReservacion = @idReservacion;
+    END
+END;

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -12,6 +12,7 @@ import logros from "../controllers/logros.js";
 import dashboard from "../controllers/dashboard.js";
 import correrAsignacion from "../controllers/correrAsignacion.js";
 import sendReminder2hrsBefore from "../controllers/schedules/sendReminder2hrsBefore.js";
+import estatus from "../controllers/estatus.js";
 
 const router = express.Router();
 
@@ -27,9 +28,10 @@ router.use("/perfil", perfil);
 router.use("/logros", logros);
 router.use("/dashboard", dashboard);
 router.use("/correr-asignacion", correrAsignacion);
+router.use("/estatus", estatus);
 
 router.get("/test", async () => {
     await sendReminder2hrsBefore();
-})
+});
 
 export { router };

--- a/swagger.json
+++ b/swagger.json
@@ -2645,6 +2645,56 @@
           }
         }
       }
+    },
+    "/estatus/": {
+      "get": {
+        "tags": [
+          "Estatus"
+        ],
+        "summary": "Obtiene todos los estatus",
+        "description": "Obtiene todos los estatus",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "idEstatus": {
+                        "type": "integer"
+                      },
+                      "nombre": {
+                        "type": "string"
+                      },
+                      "descripcion": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Descripción de cambios

-  Agregar estatus de "Sin preparar" para especificar aquellas reservaciones/materiales que no han sido preparadas.
- Agregar declaración de trigger que actualiza el estatus de materiales de una reservación con base en la cantidad de materiales que ya fueron preparados.
- Modificar nombre de un estatus para que sea más descriptivo.
