### PR TITLE
Actualizar endpoint de reservaciones pasando estatus default y trigge…

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -12,5 +12,5 @@ SMTP_SERVER_EMAIL=dreamlab.world.tec@gmail.com
 # Base de datos
 AZURE_SQL_USER=dreamlab-test
 AZURE_SQL_PASSWORD=y2&s96!39$7m@2^@KaRV
-AZURE_SQL_DATABASE=dream-lab-tests-11
+AZURE_SQL_DATABASE=dream-lab-tests-12
 AZURE_SQL_SERVER=dream-lab-tests.database.windows.net

--- a/controllers/reservaciones.js
+++ b/controllers/reservaciones.js
@@ -291,6 +291,7 @@ router.post("/", async (req, res) => {
     */
     try {
         const reserv = req.body;
+        reserv.estatusMateriales = 1;
         console.log(`reserv: ${JSON.stringify(reserv)}`);
         const rowsAffected = await database.create("Reservaciones", reserv);
         res.status(201).json({ rowsAffected });

--- a/queries/triggers/trg_ActualizarEstatusMateriales.sql
+++ b/queries/triggers/trg_ActualizarEstatusMateriales.sql
@@ -1,6 +1,6 @@
 CREATE OR ALTER TRIGGER trg_ActualizarEstatusMateriales
 ON ReservacionesMateriales
-AFTER UPDATE
+AFTER UPDATE, INSERT
 AS
 BEGIN
     -- Variables para guardar el id de la reservación de la cual se está
@@ -37,6 +37,13 @@ BEGIN
     BEGIN
         UPDATE Reservaciones
         SET estatusMateriales = 2
+        WHERE idReservacion = @idReservacion;
+    END
+    -- Si no hay materiales asociados con la reservacion
+    ELSE IF @allCompleted = 0 AND @noneCompleted = 0
+    BEGIN
+        UPDATE Reservaciones
+        SET estatusMateriales = 1
         WHERE idReservacion = @idReservacion;
     END
     -- Si ningún material está completado


### PR DESCRIPTION
## Descripción de cambios

-   Actualizar trigger para que se active también cuando se insertan materiales, de esta manera, cuando se agregan materiales a una reservación, se actualiza su estatus de materiales.
- Actualizar endpoint para crear reservaciones para pasar estatus default de que los materiales están preparados puesto que todavía no tiene materiales